### PR TITLE
Implement opportunities hook and table

### DIFF
--- a/app/components/OpportunitiesTable.tsx
+++ b/app/components/OpportunitiesTable.tsx
@@ -1,1 +1,40 @@
-useOpportunities.ts
+'use client';
+
+import useOpportunities from '@/hooks/useOpportunities';
+
+type Props = {
+  apiKey: string;
+  pipelineId?: string;
+};
+
+export default function OpportunitiesTable({ apiKey, pipelineId }: Props) {
+  const { opportunities, loading, error } = useOpportunities(apiKey, pipelineId);
+
+  if (loading) return <p className="text-gray-400">Loading opportunities...</p>;
+  if (error) return <p className="text-red-500">{error}</p>;
+
+  if (!opportunities.length) return <p>No opportunities found.</p>;
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm text-left">
+        <thead>
+          <tr className="border-b border-gray-700">
+            <th className="px-4 py-2">Name</th>
+            <th className="px-4 py-2">Status</th>
+            <th className="px-4 py-2">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {opportunities.map((opp) => (
+            <tr key={opp.id} className="border-b border-gray-800">
+              <td className="px-4 py-2">{opp.name || 'Unnamed'}</td>
+              <td className="px-4 py-2">{opp.status}</td>
+              <td className="px-4 py-2">£{opp.value ?? 0}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/hooks/useOpportunities.ts
+++ b/app/hooks/useOpportunities.ts
@@ -1,1 +1,52 @@
-useOpportunities.ts
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type Opportunity = {
+  id: string;
+  name?: string;
+  status?: string;
+  value?: number;
+};
+
+export default function useOpportunities(apiKey?: string, pipelineId?: string) {
+  const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!apiKey) {
+        setOpportunities([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        if (pipelineId) params.set('pipelineId', pipelineId);
+
+        const res = await fetch(`/api/opportunities?${params.toString()}`, {
+          headers: {
+            ghlapikey: apiKey,
+          },
+        });
+
+        if (!res.ok) throw new Error('Failed to fetch opportunities');
+
+        const data = await res.json();
+        setOpportunities(data.opportunities || []);
+      } catch (err: any) {
+        console.error('Failed to load opportunities', err);
+        setError(err.message || 'Failed to load opportunities');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [apiKey, pipelineId]);
+
+  return { opportunities, loading, error };
+}


### PR DESCRIPTION
## Summary
- add a React hook to fetch opportunities via the API
- build `OpportunitiesTable` component to display results
- implement opportunities page using the new table
- remove unused root opportunities page

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6877aa221b488332aeb7c6f1b3096edc