### PR TITLE
Fix Next.js build by server/client Firebase split

### DIFF
--- a/app/(authenticated)/contacts/route.ts
+++ b/app/(authenticated)/contacts/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { adminDb } from '@/lib/firebase-admin'; // ✅ Uses server-only Firestore
-import { doc, getDoc } from 'firebase-admin/firestore';
+import { adminDb } from '@/lib/firebase'; // ✅ Uses server-only Firestore
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -11,8 +10,8 @@ export async function GET(request: Request) {
   }
 
   try {
-    const docRef = doc(adminDb, 'subaccounts', subAccountId, 'branding', 'config');
-    const snap = await getDoc(docRef);
+    const docRef = adminDb.doc(`subaccounts/${subAccountId}/branding/config`);
+    const snap = await docRef.get();
 
     if (!snap.exists) {
       return NextResponse.json({ error: 'No config found' }, { status: 404 });

--- a/app/api/ghlApiKey/route.ts
+++ b/app/api/ghlApiKey/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { adminDb } from '@/lib/firebase-admin'; // ✅ Uses server-only Firestore
-import { doc, getDoc } from 'firebase-admin/firestore';
+import { adminDb } from '@/lib/firebase'; // ✅ Uses server-only Firestore
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -11,8 +10,8 @@ export async function GET(request: Request) {
   }
 
   try {
-    const docRef = doc(adminDb, 'subaccounts', subAccountId, 'branding', 'config');
-    const snap = await getDoc(docRef);
+    const docRef = adminDb.doc(`subaccounts/${subAccountId}/branding/config`);
+    const snap = await docRef.get();
 
     if (!snap.exists) {
       return NextResponse.json({ error: 'No config found' }, { status: 404 });

--- a/app/api/sync-opportunities/route.ts
+++ b/app/api/sync-opportunities/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { adminDb } from '@/lib/firebase-admin'; // ✅ Uses server-only Firestore
-import { doc, getDoc } from 'firebase-admin/firestore';
+import { adminDb } from '@/lib/firebase'; // ✅ Uses server-only Firestore
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -11,8 +10,8 @@ export async function GET(request: Request) {
   }
 
   try {
-    const docRef = doc(adminDb, 'subaccounts', subAccountId, 'branding', 'config');
-    const snap = await getDoc(docRef);
+    const docRef = adminDb.doc(`subaccounts/${subAccountId}/branding/config`);
+    const snap = await docRef.get();
 
     if (!snap.exists) {
       return NextResponse.json({ error: 'No config found' }, { status: 404 });

--- a/app/lib/firebase-admin.ts
+++ b/app/lib/firebase-admin.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { adminDb } from '@/lib/firebase-admin'; // ✅ Uses server-only Firestore
-import { doc, getDoc } from 'firebase-admin/firestore';
+import { adminDb } from '@/lib/firebase'; // ✅ Uses server-only Firestore
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -11,8 +10,8 @@ export async function GET(request: Request) {
   }
 
   try {
-    const docRef = doc(adminDb, 'subaccounts', subAccountId, 'branding', 'config');
-    const snap = await getDoc(docRef);
+    const docRef = adminDb.doc(`subaccounts/${subAccountId}/branding/config`);
+    const snap = await docRef.get();
 
     if (!snap.exists) {
       return NextResponse.json({ error: 'No config found' }, { status: 404 });

--- a/app/lib/firebase.ts
+++ b/app/lib/firebase.ts
@@ -11,4 +11,5 @@ const adminApp = getApps().length ? getApp() : initializeApp(firebaseAdminConfig
 
 const db = getFirestore(adminApp);
 
-export { db };
+// Expose as adminDb for clarity when imported elsewhere
+export { db, db as adminDb };

--- a/app/lib/firebase/getGhlApiKey.ts
+++ b/app/lib/firebase/getGhlApiKey.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { adminDb } from '@/lib/firebase-admin'; // ✅ Uses server-only Firestore
-import { doc, getDoc } from 'firebase-admin/firestore';
+import { adminDb } from '@/lib/firebase'; // ✅ Uses server-only Firestore
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -11,8 +10,8 @@ export async function GET(request: Request) {
   }
 
   try {
-    const docRef = doc(adminDb, 'subaccounts', subAccountId, 'branding', 'config');
-    const snap = await getDoc(docRef);
+    const docRef = adminDb.doc(`subaccounts/${subAccountId}/branding/config`);
+    const snap = await docRef.get();
 
     if (!snap.exists) {
       return NextResponse.json({ error: 'No config found' }, { status: 404 });

--- a/app/lib/firebaseClient.ts
+++ b/app/lib/firebaseClient.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { adminDb } from '@/lib/firebase-admin'; // ✅ Uses server-only Firestore
-import { doc, getDoc } from 'firebase-admin/firestore';
+import { adminDb } from '@/lib/firebase'; // ✅ Uses server-only Firestore
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -11,8 +10,8 @@ export async function GET(request: Request) {
   }
 
   try {
-    const docRef = doc(adminDb, 'subaccounts', subAccountId, 'branding', 'config');
-    const snap = await getDoc(docRef);
+    const docRef = adminDb.doc(`subaccounts/${subAccountId}/branding/config`);
+    const snap = await docRef.get();
 
     if (!snap.exists) {
       return NextResponse.json({ error: 'No config found' }, { status: 404 });

--- a/app/lib/ghl-sync-server.ts
+++ b/app/lib/ghl-sync-server.ts
@@ -1,6 +1,5 @@
 import { getAllContacts } from './ghl';
-import { db } from './firebase';
-import { doc, setDoc } from 'firebase/firestore';
+import { adminDb } from './firebase';
 
 export async function syncContactsToFirestoreServer(apiKey: string, subAccountId: string) {
   if (!apiKey || !subAccountId) {
@@ -10,14 +9,15 @@ export async function syncContactsToFirestoreServer(apiKey: string, subAccountId
   const contacts = await getAllContacts(apiKey);
 
   for (const contact of contacts) {
-    await setDoc(
-      doc(db, 'contacts', contact.id),
-      {
-        ...contact,
-        subAccountId,
-      },
-      { merge: true }
-    );
+    await adminDb.collection('contacts')
+      .doc(contact.id)
+      .set(
+        {
+          ...contact,
+          subAccountId,
+        },
+        { merge: true }
+      );
   }
 
   return `✅ Synced ${contacts.length} contacts`;

--- a/app/lib/ghl-sync.ts
+++ b/app/lib/ghl-sync.ts
@@ -3,7 +3,7 @@
 import { getAllContacts } from './ghl';
 import { getAuth } from 'firebase/auth';
 import { getFirestore, doc, setDoc, getDoc } from 'firebase/firestore';
-import { db, app } from './firebase';
+import { app, db } from '../firebase';
 
 export async function syncContactsToFirestore() {
   const auth = getAuth(app);

--- a/app/lib/ghl.ts
+++ b/app/lib/ghl.ts
@@ -1,7 +1,7 @@
 const GHL_API_KEY = process.env.NEXT_PUBLIC_GHL_API_KEY as string;
 
 import { getFirestore, doc, setDoc } from "firebase/firestore";
-import { app, db } from '@/lib/firebase';
+import { app } from '@/firebase';
 
 export type Contact = {
   id: string;


### PR DESCRIPTION
## Summary
- import client firebase module in GHL utilities
- export `adminDb` from server firebase setup
- adjust API routes to use server Firestore API
- rename contacts API file to `route.ts`
- fix server contact sync helper

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687cbbad343c83329b42377e4da81d09